### PR TITLE
Enable sbt-assembly to fat-pack the JAR

### DIFF
--- a/examples/twitter_sentiment_v2/backend/project/assembly.sbt
+++ b/examples/twitter_sentiment_v2/backend/project/assembly.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.url("bintray-sbt-plugins", url("http://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/examples/twitter_sentiment_v2/backend/sentiment.sbt
+++ b/examples/twitter_sentiment_v2/backend/sentiment.sbt
@@ -6,12 +6,14 @@ scalaVersion := "2.10.4"
 
 val sparkVersion = "1.5.0"
 
+libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion
-
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion
+libraryDependencies += "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided"
 
 libraryDependencies += "org.apache.lucene" % "lucene-core" % "5.3.0"
 
 libraryDependencies += "org.apache.lucene" % "lucene-analyzers-common" % "5.3.0"
 
+libraryDependencies += "com.databricks" % "spark-csv_2.10" % "1.2.0"
+
+assemblyJarName in assembly := "sentiment-project_2.10-assembly-1.0.jar"


### PR DESCRIPTION
* Move more options into the config
* Have node app reuse the config
* Track application ids

This is basically prepwork for the post-init and management scripts.  Those aren't complete yet, so I'll save them for a future PR once I work out the kinks with submitting the job in cluster mode.